### PR TITLE
[REFACTOR] Standardize GitHub templates to org style (#10)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,53 +1,132 @@
 name: Bug Report
 description: Report a bug in the AgentGram Python SDK
+title: "[Bug]: "
 labels: ["type: bug", "status: needs triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a bug! Please fill out the form below.
+        Thanks for taking the time to report a bug! Please fill out the information below to help us diagnose and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: "When I try to..., the following happens..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Install agentgram...
+        2. Run code...
+        3. See error...
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+      placeholder: "I expected..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+      placeholder: "But instead..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the SDK is affected?
+      multiple: true
+      options:
+        - SDK Core
+        - HTTP Client
+        - Models/Types
+        - Authentication
+        - Agents API
+        - Posts API
+        - Comments API
+        - Communities API
+        - Examples
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How severe is this bug?
+      options:
+        - Low - Nice to fix
+        - Medium - Should be fixed
+        - High - Important to fix soon
+        - Critical - Blocking/breaking functionality
+    validations:
+      required: false
+
   - type: input
     id: version
     attributes:
       label: SDK Version
       description: What version of agentgram are you using?
-      placeholder: "0.1.0"
+      placeholder: "e.g., 0.1.0"
     validations:
       required: true
+
   - type: input
     id: python-version
     attributes:
       label: Python Version
-      description: What Python version are you using?
-      placeholder: "3.12"
+      description: What version of Python are you using?
+      placeholder: "e.g., 3.12"
     validations:
       required: true
+
   - type: textarea
-    id: description
+    id: environment
     attributes:
-      label: Bug Description
-      description: A clear description of the bug
-    validations:
-      required: true
+      label: Environment
+      description: Any other relevant environment information
+      placeholder: "OS, pip version, etc."
+
   - type: textarea
-    id: reproduction
+    id: logs
     attributes:
-      label: Steps to Reproduce
-      description: Minimal code to reproduce the issue
-      render: python
+      label: Error Logs
+      description: If applicable, paste any error messages or stack traces
+      render: shell
     validations:
-      required: true
+      required: false
+
   - type: textarea
-    id: expected
+    id: additional
     attributes:
-      label: Expected Behavior
-      description: What did you expect to happen?
-    validations:
-      required: true
-  - type: textarea
-    id: actual
+      label: Additional Context
+      description: Add any other context about the problem here
+
+  - type: checkboxes
+    id: terms
     attributes:
-      label: Actual Behavior
-      description: What actually happened?
-    validations:
-      required: true
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: AgentGram Documentation
     url: https://agentgram.co/docs
-    about: Check the documentation first
+    about: Check the documentation for guides and API references
   - name: AgentGram Platform Issues
     url: https://github.com/agentgram/agentgram/issues
     about: For platform issues, use the main repo
+  - name: Security Issue
+    url: https://github.com/agentgram/agentgram-python/security/advisories/new
+    about: Report security vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,28 +1,97 @@
 name: Feature Request
-description: Suggest a new feature for the Python SDK
+description: Suggest a new feature or enhancement for the Python SDK
+title: "[Feature]: "
 labels: ["type: feature", "status: needs triage"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature! Please provide as much detail as possible.
+
   - type: textarea
     id: problem
     attributes:
       label: Problem Statement
-      description: What problem does this solve?
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: "I'm always frustrated when..."
     validations:
       required: true
+
   - type: textarea
     id: solution
     attributes:
       label: Proposed Solution
-      description: How should this work?
+      description: Describe the solution you'd like
+      placeholder: "I would like the SDK to..."
     validations:
       required: true
+
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives Considered
-      description: Any alternative approaches you considered?
+      description: Have you considered any alternative solutions or features?
+      placeholder: "I also thought about..."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the SDK would this affect?
+      multiple: true
+      options:
+        - SDK Core
+        - HTTP Client
+        - Models/Types
+        - Authentication
+        - Agents API
+        - Posts API
+        - Comments API
+        - Communities API
+        - Async Support
+        - Examples
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Low - Nice to have
+        - Medium - Would be helpful
+        - High - Very important
+        - Critical - Blocking my use case
+    validations:
+      required: false
+
   - type: textarea
-    id: context
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe your use case and how this feature would help
+      placeholder: "In my agent system, I need to..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
     attributes:
       label: Additional Context
-      description: Any other context or code examples
+      description: Add any other context, mockups, or examples about the feature request
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,34 @@
+---
+name: Task
+about: General task or improvement
+title: "[TASK] "
+labels: task
+assignees: ""
+---
+
+## Task Description
+
+<!-- Describe the task to be performed -->
+
+## Checklist
+
+- [ ]
+
+## Related Domain
+
+- [ ] SDK Core
+- [ ] HTTP Client
+- [ ] Models/Types
+- [ ] Authentication
+- [ ] Examples
+- [ ] Testing
+- [ ] Infrastructure
+- [ ] Documentation
+
+## Related Issues / PRs
+
+<!-- Link any related issues or pull requests -->
+
+## Additional Information
+
+<!-- Provide any additional information -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,31 @@
 ## Description
 
-Brief description of the changes.
+<!-- Provide a brief description of the changes in this PR -->
 
 ## Type of Change
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
+- [ ] Bug fix (`type: bug`)
+- [ ] New feature (`type: feature`)
+- [ ] Enhancement (`type: enhancement`)
+- [ ] Documentation (`type: documentation`)
+- [ ] Refactor (`type: refactor`)
+- [ ] Performance (`type: performance`)
+- [ ] Security (`type: security`)
+
+## Area
+
+- [ ] SDK Core (`area: sdk`)
+- [ ] HTTP Client (`area: http`)
+- [ ] Models/Types (`area: models`)
+- [ ] Authentication (`area: auth`)
+- [ ] Examples (`area: examples`)
+- [ ] Infrastructure (`area: infrastructure`)
+- [ ] Testing (`area: testing`)
 
 ## Changes Made
 
+-
+-
 -
 
 ## Related Issues
@@ -23,10 +38,31 @@ Closes #
 - [ ] Lint passes (`ruff check .`)
 - [ ] Format passes (`black --check .`)
 - [ ] Type check passes (`mypy agentgram/`)
+- [ ] Manual testing performed
+
+### Test Steps
+
+1.
+2.
+3.
+
+## Breaking Changes
+
+- [ ] Yes, this PR includes breaking changes (`breaking change`)
+  - **Describe:**
+  - **Migration guide:**
+
+- [ ] No breaking changes
 
 ## Checklist
 
 - [ ] My code follows the project's code style
+- [ ] I have performed a self-review of my code
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix/feature works
 - [ ] New and existing tests pass locally
-- [ ] I have updated the documentation accordingly
+
+## Screenshots (if applicable)
+
+## Additional Notes

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,11 @@
 changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+      - dependabot[bot]
+
   categories:
     - title: Breaking Changes
       labels:
@@ -13,6 +20,15 @@ changelog:
     - title: Documentation
       labels:
         - type: documentation
+    - title: Refactoring
+      labels:
+        - type: refactor
+    - title: Performance
+      labels:
+        - type: performance
+    - title: Security
+      labels:
+        - type: security
     - title: Dependencies
       labels:
         - dependencies


### PR DESCRIPTION
## Description

Standardize all GitHub issue/PR templates and release config to match the agentgram organization's golden standard style. Added missing task.md issue template.

## Type of Change

- [x] Refactor (`type: refactor`)

## Area

- [x] Infrastructure (`area: infrastructure`)

## Changes Made

- Overhauled `bug_report.yml` with title prefix, area/priority dropdowns, environment fields, code of conduct checkbox
- Overhauled `feature_request.yml` with title prefix, area/priority dropdowns, use case field, code of conduct checkbox
- Updated `config.yml` with security advisory contact link and improved descriptions
- Created `task.md` issue template for general tasks/improvements
- Expanded `PULL_REQUEST_TEMPLATE.md` with type/area checklists, breaking changes section, test steps, screenshots
- Updated `release.yml` with exclude rules and additional categories (refactor, performance, security)

## Related Issues

Closes #10

## Testing

- [x] Manual testing performed — all YAML is valid, markdown renders correctly

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings