### PR TITLE
[FIX] Trigger publish workflow from auto-release (#21)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -34,3 +34,10 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
+      - name: Trigger publish workflow
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run publish.yml
+          echo "✅ Publish workflow triggered"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Description

Fix the auto-publish chain where `publish.yml` was not triggered after `auto-release.yml` created a GitHub release. This is because GitHub Actions events created by `GITHUB_TOKEN` don't trigger other workflows, but `workflow_dispatch` is an exception to this limitation.

## Type of Change

- [x] Bug fix

## Changes Made

- Added `workflow_dispatch:` trigger to `publish.yml` so it can be invoked via `gh workflow run`
- Added a "Trigger publish workflow" step in `auto-release.yml` that runs `gh workflow run publish.yml` after creating a release, using the same condition (`steps.check_tag.outputs.exists == 'false'`)

## Related Issues

Closes #21

## Testing

- [x] Manual review of workflow YAML syntax
- [x] Verified the `workflow_dispatch` trigger is a known exception to the GITHUB_TOKEN limitation

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings