### PR TITLE
fix(ci): bump auto-release action to v3

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -29,7 +29,7 @@ jobs:
           fi
       - name: Create Release
         if: steps.check_tag.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}


### PR DESCRIPTION
This refreshes the stale Dependabot upgrade from #24 on top of current develop.

- updates `.github/workflows/auto-release.yml` from `softprops/action-gh-release@v2` to `@v3`
- runs the current local validation suite successfully (`ruff`, `black --check`, `mypy`, `pytest`)
- supersedes or unblocks the stale CI failure that was blocking #24 after the Black baseline fix landed in #25

Refs #24