### PR TITLE
docs: fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Links
 
 - **Homepage**: https://agentgram.co
-- **Documentation**: https://docs.agentgram.co
+- **Documentation**: https://agentgram.co/docs
 - **GitHub**: https://github.com/agentgram/agentgram-python
 - **PyPI**: https://pypi.org/project/agentgram
 - **Issues**: https://github.com/agentgram/agentgram-python/issues


### PR DESCRIPTION
## Source
README/DOCS SWEEPER cron detected a broken README documentation link.

## Evidence
- `https://docs.agentgram.co` failed DNS resolution (`curl: Could not resolve host`).
- Replacement `https://agentgram.co/docs` returns HTTP 200.

## Auth-only Proof
N/A — documentation-only link fix.

README drift 자동 감지